### PR TITLE
Clarify idle notebook time limit

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -9,6 +9,7 @@ content:
 asciidoc:
   attributes:
     page-pagination: true
+    experimental: true
 
 ui:
   bundle:

--- a/modules/chapter2/pages/resources.adoc
+++ b/modules/chapter2/pages/resources.adoc
@@ -132,7 +132,15 @@ data:
 <4> An option to enable or disable the automatic culling
 <5> How frequently the culler will check if the notebook is idle (in minutes)
 
-A notebook is considered idle when the user has not taken any action inside of the notebook such as executing a cell, creating files, or interacting with the user interface in general.
+A notebook is considered idle when no logged-in user has taken any action inside of the notebook such as executing a cell, creating files, or interacting with the user interface in general.
+
+[IMPORTANT]
+====
+If your cluster is configured to end user sessions after a certain period of time, then this setting overrides the idle notebook time limit configured in RHOAI.
+
+For example, assume you have configured your cluster to time out user sessions after one hour of inactivity, and also configured the RHOAI idle notebook time limit to five hours.
+In this case, RHOAI will stop a notebook if no logged-in user activity is detected after one hour.
+====
 
 == Managing Workbench and Model Server Sizes
 


### PR DESCRIPTION
Add a note to clarify [how the idle notebook time limit is affected by the cluster-wide session time-limit](https://docs.google.com/document/d/1_x3KrvIOINSj4JDVsc3-FousObwB13EAfpi95R4etGw/edit?disco=AAAA83Nf008)