### PR TITLE
added classroom instructions for partners

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -23,7 +23,9 @@ The PTL team acknowledges the valuable contributions of the following Red Hat as
 * John Hurlocker
 * Ravi Srinivasan
 
-== Classroom Environment
+== Classroom Environment for Red Hat Associates
+
+Red Hat associates should use the Red Hat Demo Platform to provision a classroom.
 
 Use the https://demo.redhat.com/catalog?search=Red+Hat+OpenShift+Container+Platform+4.13+Workshop&item=babylon-catalog-prod%2Fopenshift-cnv.ocp413-wksp-cnv.prod[Red Hat OpenShift Container Platform 4.13 Workshop] catalog item from Red Hat Demo Platform (RHDP).
 
@@ -47,7 +49,7 @@ Make sure that your worker nodes have enough memory to accommodate pods that con
 This classroom does *NOT* have RHOAI pre-installed.
 You install and configure a basic RHOAI instance, and then continue using this instance with other courses in the learning path.
 
-=== Alternative classroom environment on AWS
+=== Alternative classroom environment on AWS for Red Hat Associates
 
 You can also use an AWS cluster by ordering the https://demo.redhat.com/catalog?search=AWS+with+OpenShift+Open+Environment&item=babylon-catalog-prod%2Fsandboxes-gpte.sandbox-ocp.prod[AWS with OpenShift Open Environment].
 
@@ -68,6 +70,26 @@ $ *oc replace -f authentication.yaml*
 [INFO]
 ====
 The password for the `admin` and `user1...user5` users is `openshift23`.
+====
+
+== Classroom Environment for Red Hat Partners
+
+Red Hat partners should provision their own Red Hat OpenShift AI cluster using the Red Hat Hybrid Cloud Console at https://console.redhat.com/application-services/data-science.
+
+* Ensure that you provision an OpenShift 4.13 cluster with a minimum of 2 worker nodes, each with 64GB of RAM.
+
+* Configure users and authentication.
+The exercises in this course assume the existence of an `admin` user with the `cluster-admin` role and five non-admin users (`user1...user5`). You need to create an *admin* user along with the users *user1...user5*.
+To configure authentication for these users, use the sample xref:attachment$authentication.yaml[authentication.yaml] file and customize it for your environment.
++
+[subs=+quotes]
+----
+$ *oc replace -f authentication.yaml*
+----
+
+[INFO]
+====
+The password for the `admin` and `user1...user5` should be `openshift23`.
 ====
 
 == Prerequisites

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -76,7 +76,7 @@ The password for the `admin` and `user1...user5` users is `openshift23`.
 
 Red Hat partners should provision their own Red Hat OpenShift AI cluster using the Red Hat Hybrid Cloud Console at https://console.redhat.com/application-services/data-science.
 
-* Ensure that you provision an OpenShift 4.13 cluster with a minimum of 2 worker nodes, each with 64GB of RAM.
+* Ensure that you provision an OpenShift 4.13 cluster with a minimum of 3 control plane nodes (each with 4vCPU and 16GB RAM), and at least 2 worker nodes (each with 8 vCPU, and 64GB of RAM).
 
 * Configure users and authentication.
 The exercises in this course assume the existence of an `admin` user with the `cluster-admin` role and five non-admin users (`user1...user5`). You need to create an *admin* user along with the users *user1...user5*.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -31,11 +31,17 @@ Use the https://demo.redhat.com/catalog?search=Red+Hat+OpenShift+Container+Platf
 
 When ordering this demo item:
 
-* Select at least two users in the `User Count` field.
-Having two users is required for the user management exercise.
+* Select `Practice/Enablement` for the `Activity` field, and `Learning about the product` for the `Purpose`.
+
+* Leave the `Salesforce ID` blank.
+
+* Select *5* users in the `User Count` field.
+Having at least two users is required for the user management exercise.
 
 * In the `OpenShift worker memory size` field, select `64Gi`.
 This size might be required if you run multiple workbenches and pipelines simultaneously.
+
+* Review the auto-stop and auto-destroy timers. You can change this later after classroom provisioning by opening a ticket with the RHDP team.
 
 [IMPORTANT]
 ====
@@ -53,9 +59,18 @@ You install and configure a basic RHOAI instance, and then continue using this i
 
 You can also use an AWS cluster by ordering the https://demo.redhat.com/catalog?search=AWS+with+OpenShift+Open+Environment&item=babylon-catalog-prod%2Fsandboxes-gpte.sandbox-ocp.prod[AWS with OpenShift Open Environment].
 
+This classroom does *NOT* have RHOAI pre-installed.
+You install and configure a basic RHOAI instance, and then continue using this instance with other courses in the learning path.
+
 If you use this item, you must:
 
+* Select `Practice/Enablement` for the `Activity` field, and `Learning about the product` for the `Purpose`.
+
+* Leave the `Salesforce ID` blank.
+
 * Make sure that you select `3` as the control plane count and `4.13` as the OpenShift version.
+
+* Review the auto-stop and auto-destroy timers. You can change this later after classroom provisioning by opening a ticket with the RHDP team.
 
 * Configure users and authentication.
 The AWS item is only preconfigured with the `kubeadmin` user, which does not have the `cluster-admin` role assigned.
@@ -74,9 +89,9 @@ The password for the `admin` and `user1...user5` users is `openshift23`.
 
 == Classroom Environment for Red Hat Partners
 
-Red Hat partners should provision their own Red Hat OpenShift AI cluster using the Red Hat Hybrid Cloud Console at https://console.redhat.com/application-services/data-science.
+Red Hat partners should provision their own Red Hat OpenShift cluster using the Red Hat Hybrid Cloud Console at https://console.redhat.com/openshift/overview.
 
-* Ensure that you provision an OpenShift 4.13 cluster with a minimum of 3 control plane nodes (each with 4vCPU and 16GB RAM), and at least 2 worker nodes (each with 8 vCPU, and 64GB of RAM).
+* Ensure that you provision an OpenShift 4.13 cluster with a minimum of 3 control plane nodes (each with 4vCPU and 16GB RAM), and 3 worker nodes (each with 8 vCPU, and 64GB of RAM).
 
 * Configure users and authentication.
 The exercises in this course assume the existence of an `admin` user with the `cluster-admin` role and five non-admin users (`user1...user5`). You need to create an *admin* user along with the users *user1...user5*.

--- a/modules/chapter1/pages/upgrading-rhods.adoc
+++ b/modules/chapter1/pages/upgrading-rhods.adoc
@@ -18,11 +18,9 @@ install-w6lqv   rhods-operator.2.1.0   Manual     true    <2>
 <2> *Installplan* for the currently installed version. It's been approved and the version is currently installed.
 
 
-Installplan is approved either automatically when a new version is available without user's intervention or requires a manual approval. Whether the approval is automatic or manual depends on the value of the xref:rhods-install-cli.adoc#subscription[installPlanApproval] attribute of the operator's subscription. When it is set to _Automatic_ the *installplan* is approved automaticaly and installation starts without user's intervention. _Manual_ value requires a manual approval.
+Installplan is approved either automatically when a new version is available without user's intervention or requires a manual approval. Whether the approval is automatic or manual depends on the value of the *installPlanApproval* attribute of the operator's subscription. When it is set to _Automatic_ the *installplan* is approved automaticaly and installation starts without user's intervention. _Manual_ value requires a manual approval.
 
 Approvals can be set from the web console as well as from the CLI.
-
-Manual approvals done from the CLI are discussed in the xref:rhods-install-cli.adoc#manual_approval[Approving Installation Manualy] section and are exactly the same as for the installation.
 
 The following demonstration shows an upgrade with a manual approval done from the web console. 
 


### PR DESCRIPTION
@jramcast - please review this classroom provisioning instructions for Red Hat partners who do not have access to RHDP.

Please check:

- vCPU and RAM sizing
- how many control and worker nodes?
- instructions for admin user and user1...user5
- I know we did not not test on non-RHDP platforms, but what other issues will partners hit if they provision a plain OCP 4.13 cluster on-prem or ROSA?