### PR TITLE
Update(docs): TrustyAI, Component name, example CLI

### DIFF
--- a/modules/chapter1/pages/rhods-install-web-console.adoc
+++ b/modules/chapter1/pages/rhods-install-web-console.adoc
@@ -88,7 +88,7 @@ spec:
     ray:
       managementState: Removed
     trustyai:
-      managementState: Managed
+      managementState: Removed
     workbenches:
       managementState: Managed
 
@@ -106,7 +106,7 @@ You may also check the status of individual installed components by looking at t
 +
 image::rhods2-conditions.png[title=Conditions of individual components]
 +
-Each condition is represented by a *type* and a *status*. The *Type* is a string describing the condition, for instance _odh-dashboardReady_ and the status says whether it is _true_ or not. The following example shows the *Ready* status of the Dashboard component.
+Each condition is represented by a *type* and a *status*. The *Type* is a string describing the condition, for instance _dashboardReady_ and the status says whether it is _true_ or not. The following example shows the *Ready* status of the Dashboard component.
 +
 [subs=+quotes]
 ----

--- a/modules/chapter1/pages/uninstalling-rhods.adoc
+++ b/modules/chapter1/pages/uninstalling-rhods.adoc
@@ -22,7 +22,7 @@ Alternatively, you can delete the *DataScienceCluster* objects from the CLI.
 +
 [subs=+quotes]
 ----
-$ *oc delete datasciencecluster $(oc get datasciencecluster --no-headers |  awk '{print $1}')*
+$ *oc delete datasciencecluster default-dsc*
 
 datasciencecluster.datasciencecluster.opendatahub.io "default-dsc" deleted
 ----
@@ -37,7 +37,7 @@ alternatively you can delete the *DCSI* objects from the CLI.
 +
 [subs=+quotes]
 ----
-*$ oc delete dscinitialization $(oc get dscinitialization --no-headers |  awk '{print $1}')*
+*$ oc delete dscinitialization default-dsci*
 
 dscinitialization.dscinitialization.opendatahub.io "default-dsci" deleted
 ----
@@ -73,6 +73,7 @@ namespace "redhat-ods-operator" deleted
 
 . Delete the namespaces that the Operator created during 
 installation. They are labeled with label _opendatahub.io/generated-namespace=true_.
+Deleting namespace _rhods-notebooks_ leads to Persistent Volume Claims (PVC) being used by Workbench get deleted as well.
 +
 Navigate to *Administration* -> *Namespaces*, filter the namespaces using the label _opendatahub.io/generated-namespace=true_ and delete them.
 +
@@ -97,10 +98,6 @@ Alternatively you can delete them from the CLI.
 +
 [subs=+quotes]
 ----
-*$ oc get ns -l opendatahub.io/dashboard=true*
-NAME               STATUS   AGE
-my-rhods-project   Active   6h22m
-
 *$ oc delete ns -l opendatahub.io/dashboard=true*
 namespace "my-rhods-project" deleted
 ----

--- a/modules/chapter1/pages/upgrading-rhods.adoc
+++ b/modules/chapter1/pages/upgrading-rhods.adoc
@@ -8,8 +8,8 @@ When an upgrade is available *OLM* creates an *Installplan* for the new version.
 ----
 *$ oc get installplan -n redhat-ods-operator*
 NAME            CSV                    APPROVAL   APPROVED
-install-sp49w   rhods-operator.2.2.0   Manual     false   <1>
-install-w6lqv   rhods-operator.2.1.0   Manual     true    <2>
+install-sp49w   rhods-operator.2.7.0   Manual     false   <1>
+install-w6lqv   rhods-operator.2.6.0   Manual     true    <2>
 ----
 <1> *Installplan* for the new version of the operator which has not been approved yet. It has to be approved in order to start the upgrade.
 <2> *Installplan* for the currently installed version. It's been approved and the version is currently installed.


### PR DESCRIPTION
- TrustyAI should not set to Managed
- odh-dashboard is for upstream, in RHOAI it is dashboard
- DSCI/DSC CR has default name, to simplify CLI
- Remove "get" CLI which is not necessary for deletion